### PR TITLE
Corrected a typo for 'component' under 'Multiple Launch Configurations'

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
         <div class="column is-5">
           <section>
             <p>VS Code can launch and attach the debugger across multiple processes. This is called a "Compound Launch Configuration".
-              This is useful when dealing with a front-end heavy application that contains both a server comonent and some
+              This is useful when dealing with a front-end heavy application that contains both a server component and some
               sort of built-in development server (such as Webpack) which is handling live-reloads.            </p>
 
             <br>


### PR DESCRIPTION
@burkeholland  This pull request is fir fixing a typo for 'component' under the 'Multiple Launch Configurations' label.